### PR TITLE
detect file type by shabang

### DIFF
--- a/ftdetect/execline.vim
+++ b/ftdetect/execline.vim
@@ -1,1 +1,1 @@
-au! BufNewFile,BufRead *.eb setf execline
+au BufNewFile,BufRead * if match(getline('1'), "#!.*/execlineb") >= 0 | setf execline | endif


### PR DESCRIPTION
There seems no well-established extension for execline scripts.

In most case execline script is named as `run` in s6 service dir.
So it's better to detect file type from the shabang.